### PR TITLE
add support for plugin configuration

### DIFF
--- a/plugin-babel.js
+++ b/plugin-babel.js
@@ -83,6 +83,8 @@ exports.translate = function(load) {
     babelOptions.plugins.forEach(function(plugin) {
       if (typeof plugin == 'string')
         pluginAndPresetModuleLoads.push(pluginLoader['import'](plugin, module.id));
+      else if (plugin instanceof Array && typeof plugin[0] == 'string')
+        pluginAndPresetModuleLoads.push(pluginLoader['import'](plugin[0], module.id));
     });
 
   return Promise.all(pluginAndPresetModuleLoads)
@@ -125,6 +127,8 @@ exports.translate = function(load) {
       babelOptions.plugins.forEach(function(plugin) {
         if (typeof plugin == 'string')
           plugins.push(pluginAndPresetModules[curPluginOrPresetModule++]);
+        else if (plugin instanceof Array && typeof plugin[0] == 'string')
+          plugins.push([pluginAndPresetModules[curPluginOrPresetModule++], plugin[1]]);
         else
           plugins.push(plugin);
       });


### PR DESCRIPTION
in a form of `plugins: [["name", options], ["other-name", otherOptions]]`

like:

```
babelOptions: {
    "plugins": [
      [ "react-transform", {
        "transforms": [{"transform": "react-transform-jspm-hmr"}]
      }]
    ]
}
```

With this, I'm able to configure https://github.com/gaearon/babel-plugin-react-transform with correct transformations.
The whole project available at https://github.com/mikz/jspm-react-hot-reload.