### PR TITLE
Add repository, license, bugs, and homepage to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,15 @@
   "version": "0.0.15",
   "registry": "npm",
   "jspmPackage": true,
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/systemjs/plugin-babel.git"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/systemjs/plugin-babel/issues"
+  },
+  "homepage": "https://github.com/systemjs/plugin-babel",
   "scripts": {
     "build": "./build.sh",
     "clear": "rm -rf build-babel/node_modules build-babel/jspm_packages regenerator-runtime.js systemjs-babel-node.js systemjs-babel-browser.js",


### PR DESCRIPTION
I am trying to generate a [webjar](http://www.webjars.org/) for this package, but the UI reports

```
Failed!
The source repository for systemjs-plugin-babel 0.0.15 could not be determined but is required to published to Maven Central. This will need to be fixed in the project's package metadata.
```

This PR fixes this. If the PR is accepted, may I ask for a new release?