### PR TITLE
Propagate `babelOptions.moduleIds` downstream

### DIFF
--- a/plugin-babel.js
+++ b/plugin-babel.js
@@ -171,7 +171,7 @@ exports.translate = function(load, traceOpts) {
       plugins: plugins,
       presets: presets,
       filename: load.address,
-      moduleIds: false,
+      moduleIds: babelOptions.moduleIds,
       sourceMaps: traceOpts && traceOpts.sourceMaps || babelOptions.sourceMaps,
       inputSourceMap: load.metadata.sourceMap,
       compact: babelOptions.compact,


### PR DESCRIPTION
Modules loaded in-browser are not aware of their moduleIds.
In particular, this is problematic for Angular 2 projects with relative component template paths.

Code like this throws `'module' not defined`:

```
@Component({
  moduleId: module.id,
  selector: "my-component",
  templateUrl: "my-component.html"
})
export class MyComponent {
...
```
