### PR TITLE
Fixed mapping to original file in sourcemap

### DIFF
--- a/plugin-babel.js
+++ b/plugin-babel.js
@@ -171,6 +171,7 @@ exports.translate = function(load, traceOpts) {
       plugins: plugins,
       presets: presets,
       filename: load.address,
+      sourceFileName: load.address,
       moduleIds: false,
       sourceMaps: traceOpts && traceOpts.sourceMaps || babelOptions.sourceMaps,
       inputSourceMap: load.metadata.sourceMap,


### PR DESCRIPTION
babel swallows the path of the source file if `sourceFileName` is not defined.