### PR TITLE
Bundle babel-preset-react, false by default (closes #76)

### DIFF
--- a/build-babel/jspm.config.js
+++ b/build-babel/jspm.config.js
@@ -1,12 +1,110 @@
 SystemJS.config({
   devConfig: {
     "map": {
-      "plugin-babel": "npm:systemjs-plugin-babel@0.0.16"
+      "plugin-babel": "npm:systemjs-plugin-babel@0.0.16",
+      "babel-runtime": "npm:babel-runtime@5.8.38",
+      "babel-preset-react": "npm:babel-preset-react@6.22.0"
+    },
+    "packages": {
+      "npm:babel-preset-react@6.22.0": {
+        "map": {
+          "babel-plugin-syntax-flow": "npm:babel-plugin-syntax-flow@6.18.0",
+          "babel-plugin-syntax-jsx": "npm:babel-plugin-syntax-jsx@6.18.0",
+          "babel-plugin-transform-flow-strip-types": "npm:babel-plugin-transform-flow-strip-types@6.22.0",
+          "babel-plugin-transform-react-display-name": "npm:babel-plugin-transform-react-display-name@6.22.0",
+          "babel-plugin-transform-react-jsx": "npm:babel-plugin-transform-react-jsx@6.22.0",
+          "babel-plugin-transform-react-jsx-self": "npm:babel-plugin-transform-react-jsx-self@6.22.0",
+          "babel-plugin-transform-react-jsx-source": "npm:babel-plugin-transform-react-jsx-source@6.22.0"
+        }
+      },
+      "npm:babel-plugin-transform-flow-strip-types@6.22.0": {
+        "map": {
+          "babel-plugin-syntax-flow": "npm:babel-plugin-syntax-flow@6.18.0",
+          "babel-runtime": "npm:babel-runtime@6.22.0"
+        }
+      },
+      "npm:babel-plugin-transform-react-jsx@6.22.0": {
+        "map": {
+          "babel-plugin-syntax-jsx": "npm:babel-plugin-syntax-jsx@6.18.0",
+          "babel-runtime": "npm:babel-runtime@6.22.0",
+          "babel-helper-builder-react-jsx": "npm:babel-helper-builder-react-jsx@6.22.0"
+        }
+      },
+      "npm:babel-plugin-transform-react-jsx-self@6.22.0": {
+        "map": {
+          "babel-plugin-syntax-jsx": "npm:babel-plugin-syntax-jsx@6.18.0",
+          "babel-runtime": "npm:babel-runtime@6.22.0"
+        }
+      },
+      "npm:babel-plugin-transform-react-jsx-source@6.22.0": {
+        "map": {
+          "babel-plugin-syntax-jsx": "npm:babel-plugin-syntax-jsx@6.18.0",
+          "babel-runtime": "npm:babel-runtime@6.22.0"
+        }
+      },
+      "npm:babel-plugin-transform-react-display-name@6.22.0": {
+        "map": {
+          "babel-runtime": "npm:babel-runtime@6.22.0"
+        }
+      },
+      "npm:babel-helper-builder-react-jsx@6.22.0": {
+        "map": {
+          "babel-runtime": "npm:babel-runtime@6.22.0",
+          "lodash": "npm:lodash@4.17.4",
+          "babel-types": "npm:babel-types@6.22.0",
+          "esutils": "npm:esutils@2.0.2"
+        }
+      },
+      "npm:babel-runtime@6.22.0": {
+        "map": {
+          "regenerator-runtime": "npm:regenerator-runtime@0.10.1",
+          "core-js": "npm:core-js@2.4.1"
+        }
+      },
+      "npm:babel-types@6.22.0": {
+        "map": {
+          "esutils": "npm:esutils@2.0.2",
+          "lodash": "npm:lodash@4.17.4",
+          "babel-runtime": "npm:babel-runtime@6.22.0",
+          "to-fast-properties": "npm:to-fast-properties@1.0.2"
+        }
+      }
     }
   },
   transpiler: "plugin-babel",
   map: {
-    "regenerator": "github:facebook/regenerator@0.8.46"
+    "regenerator": "github:facebook/regenerator@0.8.46",
+    "http": "npm:jspm-nodelibs-http@0.2.0",
+    "net": "npm:jspm-nodelibs-net@0.2.0",
+    "tty": "npm:jspm-nodelibs-tty@0.2.0",
+    "url": "npm:jspm-nodelibs-url@0.2.0"
+  },
+  packages: {
+    "npm:url@0.11.0": {
+      "map": {
+        "punycode": "npm:punycode@1.3.2",
+        "querystring": "npm:querystring@0.2.0"
+      }
+    },
+    "npm:jspm-nodelibs-http@0.2.0": {
+      "map": {
+        "http-browserify": "npm:stream-http@2.5.0"
+      }
+    },
+    "npm:jspm-nodelibs-url@0.2.0": {
+      "map": {
+        "url-browserify": "npm:url@0.11.0"
+      }
+    },
+    "npm:stream-http@2.5.0": {
+      "map": {
+        "builtin-status-codes": "npm:builtin-status-codes@2.0.0",
+        "readable-stream": "npm:readable-stream@2.2.2",
+        "to-arraybuffer": "npm:to-arraybuffer@1.0.1",
+        "xtend": "npm:xtend@4.0.1",
+        "inherits": "npm:inherits@2.0.3"
+      }
+    }
   }
 });
 
@@ -55,17 +153,13 @@ SystemJS.config({
     "child_process": "npm:jspm-nodelibs-child_process@0.2.0",
     "events": "npm:jspm-nodelibs-events@0.2.0",
     "fs": "npm:jspm-nodelibs-fs@0.2.0",
-    "http": "npm:jspm-nodelibs-http@0.2.0",
     "module": "npm:jspm-nodelibs-module@0.2.0",
-    "net": "npm:jspm-nodelibs-net@0.2.0",
     "os": "npm:jspm-nodelibs-os@0.2.0",
     "path": "npm:jspm-nodelibs-path@0.2.1",
     "process": "npm:jspm-nodelibs-process@0.2.0",
     "regenerator-runtime": "npm:regenerator-runtime@0.10.1",
     "stream": "npm:jspm-nodelibs-stream@0.2.0",
     "string_decoder": "npm:jspm-nodelibs-string_decoder@0.2.0",
-    "tty": "npm:jspm-nodelibs-tty@0.2.0",
-    "url": "npm:jspm-nodelibs-url@0.2.0",
     "util": "npm:jspm-nodelibs-util@0.2.1",
     "vm": "npm:jspm-nodelibs-vm@0.2.0"
   },
@@ -171,12 +265,6 @@ SystemJS.config({
       "map": {
         "inherits": "npm:inherits@2.0.3",
         "readable-stream": "npm:readable-stream@2.2.2"
-      }
-    },
-    "npm:url@0.11.0": {
-      "map": {
-        "punycode": "npm:punycode@1.3.2",
-        "querystring": "npm:querystring@0.2.0"
       }
     },
     "npm:babel-plugin-transform-es2015-function-name@6.9.0": {
@@ -587,16 +675,6 @@ SystemJS.config({
         "is-finite": "npm:is-finite@1.0.2"
       }
     },
-    "npm:jspm-nodelibs-http@0.2.0": {
-      "map": {
-        "http-browserify": "npm:stream-http@2.5.0"
-      }
-    },
-    "npm:jspm-nodelibs-url@0.2.0": {
-      "map": {
-        "url-browserify": "npm:url@0.11.0"
-      }
-    },
     "npm:jspm-nodelibs-os@0.2.0": {
       "map": {
         "os-browserify": "npm:os-browserify@0.2.1"
@@ -731,15 +809,6 @@ SystemJS.config({
         "lodash": "npm:lodash@4.17.4",
         "detect-indent": "npm:detect-indent@4.0.0",
         "jsesc": "npm:jsesc@1.3.0"
-      }
-    },
-    "npm:stream-http@2.5.0": {
-      "map": {
-        "builtin-status-codes": "npm:builtin-status-codes@2.0.0",
-        "readable-stream": "npm:readable-stream@2.2.2",
-        "to-arraybuffer": "npm:to-arraybuffer@1.0.1",
-        "xtend": "npm:xtend@4.0.1",
-        "inherits": "npm:inherits@2.0.3"
       }
     },
     "npm:babel-code-frame@6.20.0": {

--- a/build-babel/package.json
+++ b/build-babel/package.json
@@ -27,6 +27,7 @@
       "babel-plugin-transform-es2015-unicode-regex": "npm:babel-plugin-transform-es2015-unicode-regex@^6.3.13",
       "babel-plugin-transform-regenerator": "npm:babel-plugin-transform-regenerator@^6.3.18",
       "babel-plugin-transform-runtime": "npm:babel-plugin-transform-runtime@^6.3.13",
+      "babel-preset-react": "npm:babel-preset-react@^6.22.0",
       "babel-preset-stage-1": "npm:babel-preset-stage-1@^6.5.0",
       "babel-preset-stage-2": "npm:babel-preset-stage-2@^6.5.0",
       "babel-preset-stage-3": "npm:babel-preset-stage-3@^6.3.13",
@@ -45,20 +46,23 @@
       "crypto": "npm:jspm-nodelibs-crypto@^0.2.0",
       "events": "npm:jspm-nodelibs-events@^0.2.0",
       "fs": "npm:jspm-nodelibs-fs@^0.2.0",
-      "http": "npm:jspm-nodelibs-http@^0.2.0",
       "module": "npm:jspm-nodelibs-module@^0.2.0",
-      "net": "npm:jspm-nodelibs-net@^0.2.0",
       "os": "npm:jspm-nodelibs-os@^0.2.0",
       "path": "npm:jspm-nodelibs-path@^0.2.0",
       "process": "npm:jspm-nodelibs-process@^0.2.0",
       "stream": "npm:jspm-nodelibs-stream@^0.2.0",
       "string_decoder": "npm:jspm-nodelibs-string_decoder@^0.2.0",
-      "tty": "npm:jspm-nodelibs-tty@^0.2.0",
-      "url": "npm:jspm-nodelibs-url@^0.2.0",
       "util": "npm:jspm-nodelibs-util@^0.2.0",
       "vm": "npm:jspm-nodelibs-vm@^0.2.0"
     },
     "overrides": {
+      "npm:babel-runtime@5.8.38": {
+        "main": false,
+        "dependencies": {},
+        "optionalDependencies": {
+          "core-js": "^1.2.0"
+        }
+      },
       "npm:debug@2.6.0": {
         "main": "src/browser.js",
         "jspmNodeConversion": false,
@@ -91,13 +95,6 @@
         "jspmNodeConversion": false,
         "format": "cjs"
       },
-      "npm:punycode@1.3.2": {
-        "map": {
-          "./punycode.js": {
-            "node": "@node/punycode"
-          }
-        }
-      },
       "npm:querystring@0.2.0": {
         "map": {
           "./index.js": {
@@ -105,31 +102,10 @@
           }
         }
       },
-      "npm:stream-browserify@2.0.1": {
-        "map": {
-          "./index.js": {
-            "node": "@node/stream"
-          }
-        }
-      },
-      "npm:stream-http@2.5.0": {
-        "map": {
-          "./index.js": {
-            "node": "@node/http"
-          }
-        }
-      },
       "npm:string_decoder@0.10.31": {
         "map": {
           "./index.js": {
             "node": "@node/string_decoder"
-          }
-        }
-      },
-      "npm:url@0.11.0": {
-        "map": {
-          "./url.js": {
-            "node": "@node/url"
           }
         }
       }

--- a/build-babel/systemjs-babel.js
+++ b/build-babel/systemjs-babel.js
@@ -20,12 +20,14 @@ export let runtimeTransform = {
 import p1 from 'babel-preset-stage-1';
 import p2 from 'babel-preset-stage-2';
 import p3 from 'babel-preset-stage-3';
+import pReact from 'babel-preset-react';
 
 let pluginsStage1 = p1.plugins;
 let pluginsStage2 = p2.plugins;
 let pluginsStage3 = p3.plugins;
+let pluginsReact  = pReact.plugins;
 
-export { pluginsStage1, pluginsStage2, pluginsStage3 }
+export { pluginsStage1, pluginsStage2, pluginsStage3, pluginsReact }
 
 // ES2015 plugins to keep in sync with https://github.com/babel/babel/blob/master/packages/babel-preset-es2015/index.js
 import templateLiterals from 'babel-plugin-transform-es2015-template-literals';

--- a/plugin-babel.js
+++ b/plugin-babel.js
@@ -7,6 +7,7 @@ var modulesRegister = require('systemjs-babel-build').modulesRegister;
 var stage3 = require('systemjs-babel-build').pluginsStage3;
 var stage2 = require('systemjs-babel-build').pluginsStage2;
 var stage1 = require('systemjs-babel-build').pluginsStage1;
+var react = require('systemjs-babel-build').pluginsReact;
 
 var externalHelpers = require('systemjs-babel-build').externalHelpers;
 var runtimeTransform = require('systemjs-babel-build').runtimeTransform;
@@ -44,6 +45,7 @@ function prepend(a, b) {
  *   stage3: true / false (defaults to true)
  *   stage2: true / false (defaults to true)
  *   stage1: true / false (defaults to false)
+ *   react: true / false (defaults to false)
  *   plugins: array of custom plugins (objects or module name strings)
  *   presets: array of custom presets (objects or module name strings)
  *   compact: as in Babel
@@ -58,6 +60,7 @@ var defaultBabelOptions = {
   stage3: true,
   stage2: true,
   stage1: false,
+  react: false,
   compact: false,
   comments: true
 };
@@ -146,6 +149,11 @@ exports.translate = function(load, traceOpts) {
     if (babelOptions.stage1)
       presets.push({
         plugins: stage1
+      });
+
+    if (babelOptions.react)
+      presets.push({
+        plugins: react
       });
 
     if (babelOptions.presets)


### PR DESCRIPTION
Everything works fine, except the jspm install for `npm:babel-preset-react` changed large portions of the config file, so you might want to do a quick scan to make sure I've done this right.

The resulting `systemjs-babel-browser.js` file is about 65K (~9%) larger than before (a bit up from my estimate of 50K), weighing in at just under 800K.  Not sure if this is relevant or not since most uses of `systemjs-babel-browser.js` will be for testing or local development.