### PR TITLE
fix babelOptions wrong position when use with jsx

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ To use React with JSX support set:
 SystemJS.config({
   meta: {
     '*.js': {
-      react: true
+      babelOptions: {
+        react: true
+      }
     }
   }
 });


### PR DESCRIPTION
In README, `react: true` should be in babelOptions.

I updated my [systemjs-example](https://github.com/Treri/systemjs-example) for using systemjs to load es6 module, jsx, ts and tsx, and found the wrong react config position. This lead to my long time fail when using babel to transpile jsx files on the fly